### PR TITLE
Fix issue with Network + DB graph not loading correctly

### DIFF
--- a/hivtrace/index.html
+++ b/hivtrace/index.html
@@ -303,7 +303,7 @@ var init = function(data) {
         user_graph.update_volatile_elements (d3.select (node_table));
   });
 
-  if(data.lanl_trace_results > 0) {
+  if(data.lanl_trace_results) {
     // Only if the comparison was done
     var lanl_network_container     = '#lanl-network_tag',
         lanl_network_status_string = '#lanl-network_status_string',
@@ -313,7 +313,7 @@ var init = function(data) {
         lanl_csvexport_label       = '#lanl-csvexport',
         lanl_button_bar_prefix     = 'lanl_network_ui_bar';
 
-    d3.select ("#lanl-trace-results").classed ("disabled", false);
+    d3.select ("#lanl-result-tab").classed ("disabled", false);
 
     var lanl_graph = data.lanl_trace_results;
     var lanl_graph_rendered = new datamonkey.hivtrace.cluster_network_graph(lanl_graph, lanl_network_container, lanl_network_status_string, lanl_network_warning, lanl_button_bar_prefix, attributes, filter_edges_toggle, null, null, parent_container);


### PR DESCRIPTION
When loading a json file that was produced by hivtrace with the -c argument, the Network + DB graph fails to load. This pull request changes the comparison in the js to fix that correctly enables the tab when present.